### PR TITLE
fix - specify CXX Standard to build "socketpp" on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ cmake_minimum_required(VERSION 3.10)
 
 project(yocto-tls)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+
 FetchContent_Declare(
   libtomcrypt
   GIT_REPOSITORY https://github.com/libtom/libtomcrypt


### PR DESCRIPTION
Hi @matvey-mukha,

Thanks for this great repo.

At present, the compilation fails on macOS. It fails with multiple errors and warnings when compiling `socketpp` library.

All error messages are about the usage of C++11 extensions.

This pull request fixes it by specifying the minimum requirement of C++11. CMake uses this to pass the appropriate argument when compiling `socketpp`.

Regards
Kapil